### PR TITLE
chore: include build and deploy deps in prod to fix heroku deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,7 @@
     "test": "ava client/src/**/*.test.js server/**/*.test.js"
   },
   "dependencies": {
-    "express": "^4.15.4"
-  },
-  "devDependencies": {
-    "ava": "^0.22.0",
+    "express": "^4.15.4",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-runtime": "^6.23.0",
@@ -32,6 +29,14 @@
     "babel-preset-latest": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "css-loader": "^0.28.7",
+    "html-webpack-plugin": "^2.30.1",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
+    "style-loader": "^0.18.2",
+    "webpack": "^3.6.0"
+  },
+  "devDependencies": {
+    "ava": "^0.22.0",
     "eslint": "^4.7.1",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.7.0",
@@ -39,16 +44,11 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-react": "^7.3.0",
     "eslint-plugin-standard": "^3.0.1",
-    "html-webpack-plugin": "^2.30.1",
     "ignore-styles": "^5.0.1",
     "nodemon": "^1.12.1",
     "npm-run-all": "^4.1.1",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
-    "style-loader": "^0.18.2",
     "supertest": "^3.0.0",
-    "supertest-as-promised": "^4.0.2",
-    "webpack": "^3.6.0"
+    "supertest-as-promised": "^4.0.2"
   },
   "ava": {
     "babel": "inherit",


### PR DESCRIPTION
To deploy our app successfully to Heroku, we need our build dependencies installed, so that Heroku can run Webpack before starting the server. To tell Heroku to do this, we simply move our build dependencies from `devDependencies` to `dependencies` in the `package.json` file.