### PR TITLE
Chore/#153163742 - Deploy app to test environment on DigitalOcean from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,38 @@
+sudo: required
+
 language: node_js
-before_install: yarn global add greenkeeper-lockfile@1
-before_script: greenkeeper-lockfile-update
-script:
-- yarn build
-- yarn test
-after_script: greenkeeper-lockfile-upload
-cache:
-  directories:
-  - node_modules
-  yarn: true
-notifications:
-  email: false
+
+services:
+- docker
+
 branches:
   only:
   - master
   - /^greenkeeper/.*$/
+
+before_install: yarn global add greenkeeper-lockfile@1
+
+before_script: greenkeeper-lockfile-update
+
+script:
+- yarn build
+- yarn test
+
+after_script: greenkeeper-lockfile-upload
+
+after_success:
+- if [ "$TRAVIS_BRANCH" == "master" ]; then
+    $TRAVIS_BUILD_DIR/deploy/run.sh ci_deploy_to_test
+  fi
+
+cache:
+  directories:
+  - node_modules
+  yarn: true
+
+notifications:
+  email: false
+
 notifications:
   slack:
     secure: "$SLACK_TOKEN"
-deploy:
-  provider: heroku
-  api_key:
-    secure: "$HEROKU_API_KEY"
-  app:
-    master: calltocode

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,8 +1,25 @@
 FROM node:9.2.0-alpine
 
+ARG DB_USER=user
+ARG DB_PASS=pass
+ARG NODE_ENV=test
+ARG DB_URL=127.0.0.1
+
+ENV WORKDIR=/home
+ENV DB_USER=$DB_USER
+ENV DB_PASS=$DB_PASS
+ENV NODE_ENV=$NODE_ENV
+ENV DB_URL=$DB_URL
+
 RUN apk update && \
     apk add yarn bash
 RUN rm -rf /var/cache/apk/*
 
-WORKDIR /home
+COPY package.json yarn.lock $WORKDIR/
+RUN cd $WORKDIR && \
+    yarn --production
+COPY deploy/dist ${WORKDIR}/
+
+WORKDIR $WORKDIR
 EXPOSE 3000
+CMD [ "node", "dist/" ]

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -22,4 +22,4 @@ COPY deploy/dist ${WORKDIR}/
 
 WORKDIR $WORKDIR
 EXPOSE 3000
-CMD [ "node", "dist/" ]
+CMD [ "node", "." ]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -2,20 +2,11 @@ version: '3'
 
 services:
   app:
+    image: blueberrymozart/test-c2c
     build:
       context: .
-    volumes:
-    - ./dist:/home/dist
-    - ../package.json:/home/package.json
-    - ../yarn.lock:/home/yarn.lock
     ports:
     - 3000:3000
-    environment:
-    - DB_USER=user
-    - DB_PASS=pass
-    - NODE_ENV=test
-    - DB_URL=127.0.0.1
-    command: bash -c 'yarn --production && node dist/'
 
   db:
     image: mongo:3.4-jessie

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -4,7 +4,8 @@ services:
   app:
     image: blueberrymozart/test-c2c
     build:
-      context: .
+      context: ..
+      dockerfile: deploy/Dockerfile
     ports:
     - 3000:3000
 

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -34,6 +34,14 @@ stop () {
   popd
 }
 
+deploy_to_test () {
+  set -x
+  git checkout .
+  git checkout master
+  git pull origin master
+  start
+}
+
 info () {
 cat <<EOF
   Usage: ./deploy/run.sh <target>

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -40,7 +40,8 @@ ci_deploy_to_test () {
   docker build -t blueberrymozart/test-c2c -f deploy/Dockerfile .
   docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
   docker push blueberrymozart/test-c2c
-ssh test-c2c <<EOF
+  apt-get install sshpass
+sshpass -p "$TEST_PASSWORD" ssh "$TEST_HOST"@"$TEST_HOSTNAME" <<EOF
   cd ~/workspace/calltocode.org &&
   git checkout . &&
   git checkout master &&


### PR DESCRIPTION
A few changes:
1. Modify Dockerfile to encapsulate entire app for easy deployment.
1. Create DockerHub repository to hold deployable docker images.
1. Modify CI config to build docker image of app and push to registry after all tests succeed and have been merged into master.
1. Create a DigitalOcean droplet and setup ssh. App is accessible here: http://45.55.219.5/.

This is testable when we merge this into master. Fingers-crossed.. it works on the first try! Ran things locally, and all works, but the CI component has not been tested.

NOTE: I will modify the dockerhub account to the team account once this PR has been merged and things have been verified to be working.