### PR TITLE
Chore/#153501222 - Add unit tests for rest of server controllers

### DIFF
--- a/db/run.sh
+++ b/db/run.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 
-echo 'Stopping and removing docker container..'
+CONTAINER_NAME=c4sg
 CONTAINER_ID=$(docker ps --quiet --filter ancestor=mongo)
-docker stop $CONTAINER_ID && docker rm $CONTAINER_ID
+
+echo 'Stopping and removing docker container..'
+docker stop $CONTAINER_NAME || docker stop $CONTAINER_ID
+docker rm $CONTAINER_NAME || docker rm $CONTAINER_ID
 
 set -e
 
 echo 'Starting new docker container with MongoDB..'
-docker run --name c4sg -d -p 27017:27017 -p 28017:28017 mongo
+docker run --name $CONTAINER_NAME -d -p 27017:27017 -p 28017:28017 mongo
+
+echo "Copying seed data to docker container.."
+docker cp ./db/seedData/users.json $CONTAINER_NAME:users.json
+docker cp ./db/seedData/projects.json $CONTAINER_NAME:projects.json
 
 echo "Adding seed data to MongoDB.."
-docker cp ./db/seedData/users.json c4sg:users.json
-docker cp ./db/seedData/projects.json c4sg:projects.json
-
-docker exec c4sg mongoimport --db admin --collection users --file users.json --type json --jsonArray
-docker exec c4sg mongoimport --db admin --collection projects --file projects.json --type json --jsonArray
+docker exec $CONTAINER_NAME mongoimport --db admin --collection users --file users.json --type json --jsonArray
+docker exec $CONTAINER_NAME mongoimport --db admin --collection projects --file projects.json --type json --jsonArray

--- a/db/run.sh
+++ b/db/run.sh
@@ -12,5 +12,6 @@ docker run --name c4sg -d -p 27017:27017 -p 28017:28017 mongo
 echo "Adding seed data to MongoDB.."
 docker cp ./db/seedData/users.json c4sg:users.json
 docker cp ./db/seedData/projects.json c4sg:projects.json
-docker exec c4sg mongoimport --db admin --collection users --file users.json
-docker exec c4sg mongoimport --db admin --collection projects --file projects.json
+
+docker exec c4sg mongoimport --db admin --collection users --file users.json --type json --jsonArray
+docker exec c4sg mongoimport --db admin --collection projects --file projects.json --type json --jsonArray

--- a/db/run.sh
+++ b/db/run.sh
@@ -12,10 +12,10 @@ set -e
 echo 'Starting new docker container with MongoDB..'
 docker run --name $CONTAINER_NAME -d -p 27017:27017 -p 28017:28017 mongo
 
-echo "Copying seed data to docker container.."
+echo 'Copying seed data to docker container..'
 docker cp ./db/seedData/users.json $CONTAINER_NAME:users.json
 docker cp ./db/seedData/projects.json $CONTAINER_NAME:projects.json
 
-echo "Adding seed data to MongoDB.."
+echo 'Adding seed data to MongoDB..'
 docker exec $CONTAINER_NAME mongoimport --db admin --collection users --file users.json --type json --jsonArray
 docker exec $CONTAINER_NAME mongoimport --db admin --collection projects --file projects.json --type json --jsonArray

--- a/db/seedData/projects.json
+++ b/db/seedData/projects.json
@@ -1,50 +1,52 @@
-{
-	"_id": {
-		"$oid": "5a165cb5202e8986f99ec5c0"
+[
+	{
+		"_id": {
+			"$oid": "5a165cb5202e8986f99ec5c0"
+		},
+		"organization": "5b165cb5202e8986f99ec5c0",
+		"name": "Mary_Organization",
+		"role": "Mary Org Role 1",
+		"email": "mary@email.com",
+		"__v": 0
 	},
-	"organization": "5b165cb5202e8986f99ec5c0",
-	"name": "Mary_Organization",
-	"role": "Mary Org Role 1",
-	"email": "mary@email.com",
-	"__v": 0
-}
-{
-	"_id": {
-		"$oid": "5a165cb5202e8986f99ec5c1"
+	{
+		"_id": {
+			"$oid": "5a165cb5202e8986f99ec5c1"
+		},
+		"organization": "5b165cb5202e8986f99ec5c0",
+		"name": "Mary_Organization",
+		"role": "Mary Org Role 2",
+		"email": "mary@email.com",
+		"__v": 0
 	},
-	"organization": "5b165cb5202e8986f99ec5c0",
-	"name": "Mary_Organization",
-	"role": "Mary Org Role 2",
-	"email": "mary@email.com",
-	"__v": 0
-}
-{
-	"_id": {
-		"$oid": "5a165cb5202e8986f99ec5c2"
+	{
+		"_id": {
+			"$oid": "5a165cb5202e8986f99ec5c2"
+		},
+		"organization": "5b165cb5202e8986f99ec5c1",
+		"name": "Organization1",
+		"role": "Role1",
+		"email": "1@email.com",
+		"__v": 0
 	},
-	"organization": "5b165cb5202e8986f99ec5c1",
-	"name": "Organization1",
-	"role": "Role1",
-	"email": "1@email.com",
-	"__v": 0
-}
-{
-	"_id": {
-		"$oid": "5a165cb5202e8986f99ec5c3"
+	{
+		"_id": {
+			"$oid": "5a165cb5202e8986f99ec5c3"
+		},
+		"organization": "5b165cb5202e8986f99ec5c2",
+		"name": "Organization2",
+		"role": "Role2",
+		"email": "2@email.com",
+		"__v": 0
 	},
-	"organization": "5b165cb5202e8986f99ec5c2",
-	"name": "Organization2",
-	"role": "Role2",
-	"email": "2@email.com",
-	"__v": 0
-}
-{
-	"_id": {
-		"$oid": "5a165cb5202e8986f99ec5c4"
-	},
-	"organization": "5b165cb5202e8986f99ec5c3",
-	"name": "Organization3",
-	"role": "Role3",
-	"email": "3@email.com",
-	"__v": 0
-}
+	{
+		"_id": {
+			"$oid": "5a165cb5202e8986f99ec5c4"
+		},
+		"organization": "5b165cb5202e8986f99ec5c3",
+		"name": "Organization3",
+		"role": "Role3",
+		"email": "3@email.com",
+		"__v": 0
+	}
+]

--- a/db/seedData/users.json
+++ b/db/seedData/users.json
@@ -1,25 +1,27 @@
-{
-	"_id": {
-		"$oid": "5a1658a0327c0286c39a1deb"
+[
+	{
+		"_id": {
+			"$oid": "5a1658a0327c0286c39a1deb"
+		},
+		"usertype": "contact",
+		"email": "mary@email.com",
+		"salt" : "$2a$10$Wf/vK558w2vQm29SrH.xxO",
+	  "hash" : "$2a$10$Wf/vK558w2vQm29SrH.xxOZppqQk/5pOe5GwrYnntf7VO0gAVRp5u",
+		"organization": "5b165cb5202e8986f99ec5c0",
+		"__v": 0
 	},
-	"usertype": "contact",
-	"email": "mary@email.com",
-	"salt" : "$2a$10$Wf/vK558w2vQm29SrH.xxO",
-  "hash" : "$2a$10$Wf/vK558w2vQm29SrH.xxOZppqQk/5pOe5GwrYnntf7VO0gAVRp5u",
-	"organization": "5b165cb5202e8986f99ec5c0",
-	"__v": 0
-}
-{
-	"_id": {
-		"$oid": "5a1658a0327c0286c39a1dea"
-	},
-	"usertype": "volunteer",
-	"email": "kevin@email.com",
-	"salt" : "$2a$10$Uul1BtyDlBKWvtYabzZ4L.",
-  "hash" : "$2a$10$Uul1BtyDlBKWvtYabzZ4L.qLVuY7di8A0.Tlo2r7U2xvGpIkKmCPy",
-	"projectsAppliedFor": [
-		"5a165cb5202e8986f99ec5c1",
-		"5a165cb5202e8986f99ec5c3"
-	],
-	"__v": 0
-}
+	{
+		"_id": {
+			"$oid": "5a1658a0327c0286c39a1dea"
+		},
+		"usertype": "volunteer",
+		"email": "kevin@email.com",
+		"salt" : "$2a$10$Uul1BtyDlBKWvtYabzZ4L.",
+		"hash" : "$2a$10$Uul1BtyDlBKWvtYabzZ4L.qLVuY7di8A0.Tlo2r7U2xvGpIkKmCPy",
+		"projectsAppliedFor": [
+			"5a165cb5202e8986f99ec5c1",
+			"5a165cb5202e8986f99ec5c3"
+		],
+		"__v": 0
+	}
+]

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint-plugin-react": "^7.4.0",
     "eslint-plugin-standard": "^3.0.1",
     "ignore-styles": "^5.0.1",
+    "mongodb-memory-server": "^1.6.3",
     "nodemon": "^1.12.1",
     "npm-run-all": "^4.1.1",
     "sinon": "^4.0.0",

--- a/server/app.js
+++ b/server/app.js
@@ -1,13 +1,14 @@
-// Temporary server since supertest needs a server that doesn't call app.listen()
 const express = require('express')
 const bodyParser = require('body-parser')
 
-const { appConfig } = require('../config')
+const { appConfig } = require('./config')
+const errorHandler = require('./middleware/errorHandler')
 
 const app = express()
 
 app.use(express.static(appConfig.clientDistDir))
 app.use(bodyParser.json())
-app.use('/', require('../routes'))
+app.use('/', require('./routes'))
+app.use(errorHandler())
 
 module.exports = app

--- a/server/database/models/Project.js
+++ b/server/database/models/Project.js
@@ -1,6 +1,10 @@
 const mongoose = require('mongoose')
 
 const ProjectSchema = mongoose.Schema({
+  organization: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Organization'
+  },
   name: String,
   role: String,
   email: String
@@ -9,6 +13,7 @@ const ProjectSchema = mongoose.Schema({
 ProjectSchema.methods.toJSON = function () {
   return {
     id: this._id,
+    organization: this.organization,
     name: this.name,
     role: this.role,
     email: this.email

--- a/server/database/models/User.js
+++ b/server/database/models/User.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose')
 const jwt = require('jsonwebtoken')
+
 const { authConfig } = require('../../config')
 
 const UserSchema = mongoose.Schema({

--- a/server/index.js
+++ b/server/index.js
@@ -1,17 +1,8 @@
-const express = require('express')
-const bodyParser = require('body-parser')
+const app = require('./app')
 
 const { appConfig, databaseConfig } = require('./config')
 const database = require('./database')._init(databaseConfig.url)
-const errorHandler = require('./middleware/errorHandler')
 const logger = require('./logger')
-
-const app = express()
-
-app.use(express.static(appConfig.clientDistDir))
-app.use(bodyParser.json())
-app.use('/', require('./routes'))
-app.use(errorHandler())
 
 app.listen(appConfig.port, run)
 

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,4 @@
 const app = require('./app')
-
 const { appConfig, databaseConfig } = require('./config')
 const database = require('./database')._init(databaseConfig.url)
 const logger = require('./logger')

--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ const bodyParser = require('body-parser')
 const { appConfig, databaseConfig } = require('./config')
 const database = require('./database')._init(databaseConfig.url)
 const errorHandler = require('./middleware/errorHandler')
+const logger = require('./logger')
 
 const app = express()
 
@@ -15,13 +16,13 @@ app.use(errorHandler())
 app.listen(appConfig.port, run)
 
 async function run () {
-  console.log(`App listening on port ${appConfig.port}`)
+  logger.log(`App listening on port ${appConfig.port}`)
 
   try {
     await database.connect()
-    console.log('Database connected')
+    logger.log('Database connected')
   } catch (error) {
-    console.error('Database connection error', error)
+    logger.error('Database connection error', error)
   }
 }
 

--- a/server/index.test.js
+++ b/server/index.test.js
@@ -1,9 +1,17 @@
 import test from 'ava'
 import request from 'supertest'
-import app from './index'
 
-test('GET /: respond with html', async t => {
-  const response = await request(app).get('/')
-  t.is(response.status, 200)
-  t.is(response.type, 'text/html')
+import { before, beforeEach, afterEach, after } from './test/util'
+
+test.before(before)
+test.beforeEach(beforeEach)
+test.afterEach.always(afterEach)
+test.after.always(after)
+
+test.serial('GET /: respond with html', async t => {
+  const { app } = t.context
+  const res = await request(app).get('/')
+
+  t.is(res.status, 200)
+  t.is(res.type, 'text/html')
 })

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,4 +1,5 @@
 const jwt = require('express-jwt')
+
 const { authConfig } = require('../config')
 
 function getTokenFromHeader (req) {

--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -7,7 +7,7 @@ function errorHandler () {
     const error = { name: err.name, message: err.message, stack: err.stack }
     for (const prop in err) error[prop] = err[prop]
 
-    res.status(err.status || 500).json({ error })
+    return res.status(err.status || 500).json({ error })
   }
 }
 

--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -7,7 +7,7 @@ function errorHandler () {
     const error = { name: err.name, message: err.message, stack: err.stack }
     for (const prop in err) error[prop] = err[prop]
 
-    return res.status(err.status || 500).json({ error })
+    res.status(err.status || 500).json({ error })
   }
 }
 

--- a/server/middleware/routeLogger.js
+++ b/server/middleware/routeLogger.js
@@ -1,0 +1,8 @@
+const logger = require('../logger')
+
+function routeLogger (req, res, next) {
+  logger.log(`${req.method} ${req.originalUrl} on ${new Date()}`)
+  next()
+}
+
+module.exports = routeLogger

--- a/server/routes/api/email.js
+++ b/server/routes/api/email.js
@@ -1,6 +1,6 @@
 const router = require('express').Router()
 
-const auth = require('../auth')
+const auth = require('../../middleware/auth')
 const emailController = require('../controllers/emailController')._init()
 
 router.route('/')

--- a/server/routes/api/forgotPassword.js
+++ b/server/routes/api/forgotPassword.js
@@ -1,6 +1,6 @@
 const router = require('express').Router()
 
-const auth = require('../auth')
+const auth = require('../../middleware/auth')
 const forgotPasswordController = require('../controllers/forgotPasswordController')._init()
 
 router.route('/')

--- a/server/routes/api/projects.js
+++ b/server/routes/api/projects.js
@@ -1,6 +1,6 @@
 const router = require('express').Router()
 
-const auth = require('../auth')
+const auth = require('../../middleware/auth')
 const projectsController = require('../controllers/projectsController')._init()
 
 router.route('/')

--- a/server/routes/api/projects.js
+++ b/server/routes/api/projects.js
@@ -3,8 +3,6 @@ const router = require('express').Router()
 const auth = require('../auth')
 const projectsController = require('../controllers/projectsController')._init()
 
-router.param('project', projectsController.preloadProject)
-
 router.route('/')
   .get(auth.optional, projectsController.getProjects)
 

--- a/server/routes/api/user.js
+++ b/server/routes/api/user.js
@@ -1,6 +1,6 @@
 const router = require('express').Router()
 
-const auth = require('../auth')
+const auth = require('../../middleware/auth')
 const userController = require('../controllers/userController')._init()
 
 router.route('/')

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -3,8 +3,6 @@ const router = require('express').Router()
 const auth = require('../../middleware/auth')
 const usersController = require('../controllers/usersController')._init()
 
-// router.param('user', usersController.preloadUser)
-
 router.route('/')
   .get(auth.optional, usersController.getUsers)
   .post(usersController.signup)

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -1,6 +1,6 @@
 const router = require('express').Router()
 
-const auth = require('../auth')
+const auth = require('../../middleware/auth')
 const usersController = require('../controllers/usersController')._init()
 
 // router.param('user', usersController.preloadUser)

--- a/server/routes/controllers/forgotPasswordController.test.js
+++ b/server/routes/controllers/forgotPasswordController.test.js
@@ -1,0 +1,18 @@
+import test from 'ava'
+import request from 'supertest'
+
+import { before, beforeEach, afterEach, after } from '../../test/util'
+
+test.before(before)
+test.beforeEach(beforeEach)
+test.afterEach.always(afterEach)
+test.after.always(after)
+
+test.serial('sendVerificationCodeEmail', async t => {
+  const { app } = t.context
+  const res = await request(app)
+    .post('/api/forgot-password')
+    .send({ email: 'kevin@email.com' })
+
+  t.is(res.status, 200)
+})

--- a/server/routes/controllers/projectsController.js
+++ b/server/routes/controllers/projectsController.js
@@ -4,26 +4,9 @@ const projectsController = {
   _init (Projects = ProjectModel) {
     this.Projects = Projects
 
-    this.preloadProject = this.preloadProject.bind(this)
     this.getProjects = this.getProjects.bind(this)
     this.getProject = this.getProject.bind(this)
     return this
-  },
-
-  preloadProject (req, res, next, id) {
-    this.Projects.findById(id).exec((err, project) => {
-      if (err) {
-        return res.sendStatus(500)
-      }
-
-      if (!project) {
-        return res.sendStatus(404)
-      }
-
-      req.project = project
-
-      return next()
-    })
   },
 
   getProjects (req, res, next) {
@@ -48,7 +31,19 @@ const projectsController = {
   },
 
   getProject (req, res) {
-    return res.status(200).send(req.project.toJSON())
+    const id = req.params.project
+
+    this.Projects.findById(id).exec((err, project) => {
+      if (err) {
+        return res.sendStatus(500)
+      }
+
+      if (!project) {
+        return res.sendStatus(404)
+      }
+
+      return res.status(200).send(project.toJSON())
+    })
   }
 }
 

--- a/server/routes/controllers/projectsController.js
+++ b/server/routes/controllers/projectsController.js
@@ -30,20 +30,16 @@ const projectsController = {
     }).catch(next)
   },
 
-  getProject (req, res) {
+  getProject (req, res, next) {
     const id = req.params.project
 
-    this.Projects.findById(id).exec((err, project) => {
-      if (err) {
-        return res.sendStatus(500)
-      }
-
+    this.Projects.findById(id).then(project => {
       if (!project) {
-        return res.sendStatus(404)
+        return res.status(404).json({ error: 'Project not found' })
       }
 
-      return res.status(200).send(project.toJSON())
-    })
+      return res.status(200).json(project.toJSON())
+    }).catch(next)
   }
 }
 

--- a/server/routes/controllers/projectsController.test.js
+++ b/server/routes/controllers/projectsController.test.js
@@ -74,6 +74,16 @@ test.serial('getProject with a valid id', async t => {
   t.deepEqual(res.body, toJSON.call(project))
 })
 
+test.serial('getProject with a valid unused id should return project not found', async t => {
+  const { app } = t.context
+  const organizationId = '5b165cb5202e8986f99ec5c0'
+  const res = await request(app)
+    .get(`/api/projects/${organizationId}`)
+
+  t.is(res.status, 404)
+  t.deepEqual(res.body, { error: 'Project not found' })
+})
+
 test.serial('getProject with an invalid id should error', async t => {
   const { app } = t.context
   const res = await request(app)

--- a/server/routes/controllers/projectsController.test.js
+++ b/server/routes/controllers/projectsController.test.js
@@ -1,0 +1,83 @@
+import test from 'ava'
+import request from 'supertest'
+
+import { before, beforeEach, afterEach, after } from '../../test/util'
+import seedProjects from '../../../db/seedData/projects.json'
+import Project from '../../database/models/Project'
+
+const toJSON = Project.schema.methods.toJSON
+
+test.before(before)
+test.beforeEach(beforeEach)
+test.afterEach.always(afterEach)
+test.after.always(after)
+
+test.serial('getProjects, all', async t => {
+  const { app } = t.context
+  const res = await request(app)
+    .get('/api/projects')
+
+  t.is(res.status, 200)
+  t.is(res.body.length, seedProjects.length)
+})
+
+test.serial('getProjects, volunteer with valid projects', async t => {
+  const { app } = t.context
+  const projectsAppliedFor = ['5a165cb5202e8986f99ec5c1', '5a165cb5202e8986f99ec5c3']
+  const res = await request(app)
+    .get('/api/projects')
+    .query({ projectsAppliedFor: projectsAppliedFor.join(',') })
+
+  t.is(res.status, 200)
+  t.is(res.body.length, projectsAppliedFor.length)
+})
+
+test.serial('getProjects, volunteer with invalid projects should error', async t => {
+  const { app } = t.context
+  const res = await request(app)
+    .get('/api/projects')
+    .query({ projectsAppliedFor: 'invalid,invalid' })
+
+  t.is(res.status, 500)
+})
+
+test.serial('getProjects, contact with valid origanization', async t => {
+  const { app } = t.context
+  const organization = '5b165cb5202e8986f99ec5c0'
+  const res = await request(app)
+    .get('/api/projects')
+    .query({ organization })
+
+  t.is(res.status, 200)
+
+  for (const project of res.body) {
+    t.is(project.organization, organization)
+  }
+})
+
+test.serial('getProjects, contact with invalid organization should error', async t => {
+  const { app } = t.context
+  const res = await request(app)
+    .get('/api/projects')
+    .query({ organization: 'invalid' })
+
+  t.is(res.status, 500)
+})
+
+test.serial('getProject with a valid id', async t => {
+  const { app } = t.context
+  const project = seedProjects[0]
+  const res = await request(app)
+    .get(`/api/projects/${project._id}`)
+
+  t.is(res.status, 200)
+  t.deepEqual(res.body, toJSON.call(project))
+})
+
+test.serial('getProject with an invalid id should error', async t => {
+  const { app } = t.context
+  const res = await request(app)
+    .get('/api/projects/invalid')
+
+  t.is(res.status, 500)
+})

--- a/server/routes/controllers/projectsController.test.js
+++ b/server/routes/controllers/projectsController.test.js
@@ -1,7 +1,7 @@
 import test from 'ava'
 import request from 'supertest'
 
-import { before, beforeEach, afterEach, after } from '../../test/util'
+import { before, beforeEach, afterEach, after, formatData } from '../../test/util'
 import seedProjects from '../../../db/seedData/projects.json'
 import Project from '../../database/models/Project'
 
@@ -66,7 +66,7 @@ test.serial('getProjects, contact with invalid organization should error', async
 
 test.serial('getProject with a valid id', async t => {
   const { app } = t.context
-  const project = seedProjects[0]
+  const project = formatData(seedProjects[0])
   const res = await request(app)
     .get(`/api/projects/${project._id}`)
 

--- a/server/routes/controllers/userController.js
+++ b/server/routes/controllers/userController.js
@@ -33,7 +33,11 @@ const userController = {
         return res.sendStatus(404)
       }
 
-      const { projectsAppliedFor } = req.body.user
+      const { email, projectsAppliedFor } = req.body.user
+
+      if (typeof email !== 'undefined') {
+        user.email = email
+      }
 
       if (typeof projectsAppliedFor !== 'undefined') {
         user.projectsAppliedFor = projectsAppliedFor

--- a/server/routes/controllers/userController.js
+++ b/server/routes/controllers/userController.js
@@ -9,28 +9,24 @@ const userController = {
     return this
   },
 
-  getCurrent (req, res) {
-    this.Users.findById(req.payload.id).exec((err, user) => {
-      if (err) {
-        return res.sendStatus(500)
-      }
+  getCurrent (req, res, next) {
+    const id = req.payload.id
 
+    this.Users.findById(id).then(user => {
       if (!user) {
-        return res.sendStatus(404)
+        return res.status(404).json({ error: 'User not found' })
       }
 
-      return res.status(200).send(user.toJSON())
-    })
+      return res.status(200).json(user.toJSON())
+    }).catch(next)
   },
 
-  putCurrent (req, res) {
-    this.Users.findById(req.payload.id).exec((err, user) => {
-      if (err) {
-        return res.sendStatus(500)
-      }
+  putCurrent (req, res, next) {
+    const id = req.payload.id
 
+    this.Users.findById(id).then(user => {
       if (!user) {
-        return res.sendStatus(404)
+        return res.status(404).json({ error: 'User not found' })
       }
 
       const { email, projectsAppliedFor } = req.body.user
@@ -43,14 +39,10 @@ const userController = {
         user.projectsAppliedFor = projectsAppliedFor
       }
 
-      return user.save(err => {
-        if (err) {
-          return res.sendStatus(500)
-        }
-
+      user.save().then(() => {
         return res.status(200).send(user.toJSON())
       })
-    })
+    }).catch(next)
   }
 }
 

--- a/server/routes/controllers/userController.test.js
+++ b/server/routes/controllers/userController.test.js
@@ -1,7 +1,7 @@
 import test from 'ava'
 import request from 'supertest'
 
-import { before, beforeEach, afterEach, after } from '../../test/util'
+import { before, beforeEach, afterEach, after, formatData } from '../../test/util'
 import seedUsers from '../../../db/seedData/users.json'
 import User from '../../database/models/User'
 
@@ -14,7 +14,7 @@ test.after.always(after)
 
 test.serial('getCurrent, valid token', async t => {
   const { app } = t.context
-  const user = seedUsers[0]
+  const user = formatData(seedUsers[0])
   const token = generateSessionToken.call(user)
   const res = await request(app)
     .get('/api/user')
@@ -35,7 +35,7 @@ test.serial('getCurrent, invalid token should error unauthorized', async t => {
 
 test.serial('putCurrent, valid token', async t => {
   const { app } = t.context
-  const user = seedUsers[0]
+  const user = formatData(seedUsers[0])
   const token = generateSessionToken.call(user)
   const updatedEmail = 'updatedEmail@email.com'
   const res = await request(app)

--- a/server/routes/controllers/userController.test.js
+++ b/server/routes/controllers/userController.test.js
@@ -1,0 +1,57 @@
+import test from 'ava'
+import request from 'supertest'
+
+import { before, beforeEach, afterEach, after } from '../../test/util'
+import seedUsers from '../../../db/seedData/users.json'
+import User from '../../database/models/User'
+
+const generateSessionToken = User.schema.methods.generateSessionToken
+
+test.before(before)
+test.beforeEach(beforeEach)
+test.afterEach.always(afterEach)
+test.after.always(after)
+
+test.serial('getCurrent, valid token', async t => {
+  const { app } = t.context
+  const user = seedUsers[0]
+  const token = generateSessionToken.call(user)
+  const res = await request(app)
+    .get('/api/user')
+    .set('Authorization', `Token ${token}`)
+
+  t.is(res.status, 200)
+  t.is(res.body.email, user.email)
+})
+
+test.serial('getCurrent, invalid token should error unauthorized', async t => {
+  const { app } = t.context
+  const res = await request(app)
+    .get('/api/user')
+    .set('Authorization', 'Token invalid')
+
+  t.is(res.status, 401)
+})
+
+test.serial('putCurrent, valid token', async t => {
+  const { app } = t.context
+  const user = seedUsers[0]
+  const token = generateSessionToken.call(user)
+  const updatedEmail = 'updatedEmail@email.com'
+  const res = await request(app)
+    .put('/api/user')
+    .set('Authorization', `Token ${token}`)
+    .send({ user: { email: updatedEmail } })
+
+  t.is(res.status, 200)
+  t.is(res.body.email, updatedEmail)
+})
+
+test.serial('putCurrent, invalid token should error unauthorized', async t => {
+  const { app } = t.context
+  const res = await request(app)
+    .put('/api/user')
+    .set('Authorization', 'Token invalid')
+
+  t.is(res.status, 401)
+})

--- a/server/routes/controllers/usersController.js
+++ b/server/routes/controllers/usersController.js
@@ -4,7 +4,6 @@ const usersController = {
   _init (Users = UserModel) {
     this.Users = Users
 
-    this.preloadUser = this.preloadUser.bind(this)
     this.getUsers = this.getUsers.bind(this)
     this.signup = this.signup.bind(this)
     this.getUser = this.getUser.bind(this)
@@ -13,22 +12,6 @@ const usersController = {
     this.login = this.login.bind(this)
     this.changePassword = this.changePassword.bind(this)
     return this
-  },
-
-  preloadUser (req, res, next, id) {
-    this.Users.findById(id).exec((err, user) => {
-      if (err) {
-        return res.sendStatus(500)
-      }
-
-      if (!user) {
-        return res.sendStatus(404)
-      }
-
-      req.user = user
-
-      return next()
-    })
   },
 
   getUsers (req, res) {
@@ -55,7 +38,19 @@ const usersController = {
   },
 
   getUser (req, res) {
-    return res.status(200).json(req.user.toJSON())
+    const id = req.params.id
+
+    this.Users.findById(id).exec((err, user) => {
+      if (err) {
+        return res.sendStatus(500)
+      }
+
+      if (!user) {
+        return res.sendStatus(404)
+      }
+
+      return res.status(200).json(req.user.toJSON())
+    })
   },
 
   putUser (req, res) {},
@@ -83,7 +78,7 @@ const usersController = {
       if (err) {
         return res.sendStatus(403)
       }
-      
+
       if (!user) {
         res.statusMessage = 'Wrong email'
         return res.status(403).json({ error: 'Invalid email' })

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,14 +1,10 @@
 const router = require('express').Router()
 
+const routeLogger = require('../middleware/routeLogger')
 const indexController = require('./controllers/indexController')._init()
 
-router.use(logger)
+router.use(routeLogger)
 router.use('/api', require('./api'))
 router.get('*', indexController.getIndexPage.bind(indexController))
-
-function logger (req, res, next) {
-  console.log(`${req.method} ${req.originalUrl} on ${new Date()}`)
-  next()
-}
 
 module.exports = router

--- a/server/test/app.js
+++ b/server/test/app.js
@@ -1,0 +1,13 @@
+// Temporary server since supertest needs a server that doesn't call app.listen()
+const express = require('express')
+const bodyParser = require('body-parser')
+
+const { appConfig } = require('../config')
+
+const app = express()
+
+app.use(express.static(appConfig.clientDistDir))
+app.use(bodyParser.json())
+app.use('/', require('../routes'))
+
+module.exports = app

--- a/server/test/util.js
+++ b/server/test/util.js
@@ -1,0 +1,48 @@
+const MongodbMemoryServer = require('mongodb-memory-server').default
+const mongoose = require('mongoose')
+
+const app = require('./app')
+const Project = require('../database/models/Project')
+const User = require('../database/models/User')
+const seedProjects = require('../../db/seedData/projects.json')
+const seedUsers = require('../../db/seedData/users.json')
+
+const mongod = new MongodbMemoryServer()
+
+async function before (t) {
+  const mongoUri = await mongod.getConnectionString()
+  const options = { useMongoClient: true }
+  mongoose.Promise = global.Promise
+  mongoose.connect(mongoUri, options)
+}
+
+async function beforeEach (t) {
+  for (const seedProject of seedProjects) {
+    const project = new Project(fix(seedProject))
+    await project.save()
+  }
+
+  for (const seedUser of seedUsers) {
+    const user = new User(fix(seedUser))
+    await user.save()
+  }
+
+  t.context.app = app
+}
+
+async function afterEach (t) {
+  await Project.remove()
+  await User.remove()
+}
+
+async function after (t) {
+  mongoose.disconnect()
+  mongod.stop()
+}
+
+function fix (data) {
+  if (data['_id']['$oid']) data['_id'] = data['_id']['$oid']
+  return data
+}
+
+module.exports = { before, beforeEach, afterEach, after }

--- a/server/test/util.js
+++ b/server/test/util.js
@@ -18,12 +18,12 @@ async function before (t) {
 
 async function beforeEach (t) {
   for (const seedProject of seedProjects) {
-    const project = new Project(fix(seedProject))
+    const project = new Project(formatData(seedProject))
     await project.save()
   }
 
   for (const seedUser of seedUsers) {
-    const user = new User(fix(seedUser))
+    const user = new User(formatData(seedUser))
     await user.save()
   }
 
@@ -40,9 +40,8 @@ async function after (t) {
   mongod.stop()
 }
 
-function fix (data) {
-  if (data['_id']['$oid']) data['_id'] = data['_id']['$oid']
-  return data
+function formatData (data) {
+  return { ...data, _id: data['_id']['$oid'] }
 }
 
-module.exports = { before, beforeEach, afterEach, after }
+module.exports = { before, beforeEach, afterEach, after, formatData }

--- a/server/test/util.js
+++ b/server/test/util.js
@@ -1,7 +1,7 @@
 const MongodbMemoryServer = require('mongodb-memory-server').default
 const mongoose = require('mongoose')
 
-const app = require('./app')
+const app = require('../app')
 const Project = require('../database/models/Project')
 const User = require('../database/models/User')
 const seedProjects = require('../../db/seedData/projects.json')

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,6 +316,12 @@ async@2.1.4:
   dependencies:
     lodash "^4.14.0"
 
+async@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.4.0.tgz#4990200f18ea5b837c2cc4f8c031a6985c385611"
+  dependencies:
+    lodash "^4.14.0"
+
 async@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -1170,6 +1176,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base64-js@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"
+
 base64-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
@@ -1196,6 +1206,12 @@ binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
+bl@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.1.tgz#cac328f7bee45730d404b692203fcb590e172d5e"
+  dependencies:
+    readable-stream "^2.0.5"
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -1206,7 +1222,7 @@ bluebird@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
-bluebird@^3.0.0, bluebird@^3.4.7:
+bluebird@^3.0.0, bluebird@^3.4.7, bluebird@^3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -1356,9 +1372,28 @@ buf-compare@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buf-compare/-/buf-compare-1.0.1.tgz#fef28da8b8113a0a0db4430b0b6467b69730b34a"
 
+buffer-alloc-unsafe@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz#ffe1f67551dd055737de253337bfe853dfab1a6a"
+
+buffer-alloc@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.1.0.tgz#05514d33bf1656d3540c684f65b1202e90eca303"
+  dependencies:
+    buffer-alloc-unsafe "^0.1.0"
+    buffer-fill "^0.1.0"
+
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+
+buffer-fill@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-0.1.0.tgz#ca9470e8d4d1b977fd7543f4e2ab6a7dc95101a8"
 
 buffer-shims@~1.0.0:
   version "1.0.0"
@@ -1367,6 +1402,14 @@ buffer-shims@~1.0.0:
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
+
+buffer@^3.0.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-3.6.0.tgz#a72c936f77b96bf52f5f7e7b467180628551defb"
+  dependencies:
+    base64-js "0.0.8"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 buffer@^4.3.0:
   version "4.9.1"
@@ -1690,6 +1733,12 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
 commander@2.12.x, commander@^2.9.0, commander@~2.12.1:
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
+
+commander@~2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
+  dependencies:
+    graceful-readlink ">= 1.0.0"
 
 common-path-prefix@^1.0.0:
   version "1.0.0"
@@ -2037,6 +2086,54 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/decompress-tar/-/decompress-tar-4.1.1.tgz#718cbd3fcb16209716e70a26b84e7ba4592e5af1"
+  dependencies:
+    file-type "^5.2.0"
+    is-stream "^1.1.0"
+    tar-stream "^1.5.2"
+
+decompress-tarbz2@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz#3082a5b880ea4043816349f378b56c516be1a39b"
+  dependencies:
+    decompress-tar "^4.1.0"
+    file-type "^6.1.0"
+    is-stream "^1.1.0"
+    seek-bzip "^1.0.5"
+    unbzip2-stream "^1.0.9"
+
+decompress-targz@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/decompress-targz/-/decompress-targz-4.1.1.tgz#c09bc35c4d11f3de09f2d2da53e9de23e7ce1eee"
+  dependencies:
+    decompress-tar "^4.1.1"
+    file-type "^5.2.0"
+    is-stream "^1.1.0"
+
+decompress-unzip@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/decompress-unzip/-/decompress-unzip-4.0.1.tgz#deaaccdfd14aeaf85578f733ae8210f9b4848f69"
+  dependencies:
+    file-type "^3.8.0"
+    get-stream "^2.2.0"
+    pify "^2.3.0"
+    yauzl "^2.4.2"
+
+decompress@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.0.tgz#7aedd85427e5a92dacfe55674a7c505e96d01f9d"
+  dependencies:
+    decompress-tar "^4.0.0"
+    decompress-tarbz2 "^4.0.0"
+    decompress-targz "^4.0.0"
+    decompress-unzip "^4.0.1"
+    graceful-fs "^4.1.10"
+    make-dir "^1.0.0"
+    pify "^2.3.0"
+    strip-dirs "^2.0.0"
+
 deep-diff@^0.3.5:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
@@ -2249,6 +2346,12 @@ encoding@^0.1.11:
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
     iconv-lite "~0.4.13"
+
+end-of-stream@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.0.tgz#7a90d833efda6cfa6eac0f4949dbb0fad3a63206"
+  dependencies:
+    once "^1.4.0"
 
 enhanced-resolve@^3.4.0:
   version "3.4.1"
@@ -2720,6 +2823,12 @@ fbjs@^0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fd-slicer@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+  dependencies:
+    pend "~1.2.0"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -2732,6 +2841,18 @@ file-entry-cache@^2.0.0:
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
+
+file-type@^3.8.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
+
+file-type@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-5.2.0.tgz#2ddbea7c73ffe36368dfae49dc338c058c2b8ad6"
+
+file-type@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-6.2.0.tgz#e50cd75d356ffed4e306dc4f5bcf52a79903a919"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -2869,6 +2990,14 @@ from@~0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
 
+fs-extra@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2942,7 +3071,7 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
-get-port@^3.0.0:
+get-port@^3.0.0, get-port@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
 
@@ -2950,9 +3079,22 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
+get-stream@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
+  dependencies:
+    object-assign "^4.0.1"
+    pinkie-promise "^2.0.0"
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+getos@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/getos/-/getos-3.1.0.tgz#db3aa4df15a3295557ce5e81aa9e3e5cdfaa6567"
+  dependencies:
+    async "2.4.0"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -3053,9 +3195,13 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -3525,6 +3671,10 @@ is-my-json-valid@^2.12.4:
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
 
+is-natural-number@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
+
 is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
@@ -3767,6 +3917,12 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -3947,6 +4103,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lockfile@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.3.tgz#2638fc39a0331e9cac1a04b71799931c9c50df79"
+
 lodash-es@^4.17.3, lodash-es@^4.2.0, lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
@@ -4113,7 +4273,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.16.6, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.16.6, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4188,6 +4348,12 @@ matcher@^1.0.0:
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
+
+md5-file@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-3.2.3.tgz#f9bceb941eca2214a4c0727f5e700314e770f06f"
+  dependencies:
+    buffer-alloc "^1.1.0"
 
 md5-hex@^1.2.0, md5-hex@^1.3.0:
   version "1.3.0"
@@ -4348,6 +4514,23 @@ mongodb-core@2.1.17:
   dependencies:
     bson "~1.0.4"
     require_optional "~1.0.0"
+
+mongodb-memory-server@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server/-/mongodb-memory-server-1.6.3.tgz#fcdb83aad7e56d5e1dc918ff83a36ae2108aff92"
+  dependencies:
+    babel-runtime "^6.26.0"
+    debug "^3.1.0"
+    decompress "^4.2.0"
+    fs-extra "^4.0.2"
+    get-port "^3.2.0"
+    getos "^3.1.0"
+    lockfile "^1.0.3"
+    md5-file "^3.2.3"
+    mkdirp "^0.5.1"
+    request-promise "^4.2.2"
+    tmp "^0.0.33"
+    uuid "^3.0.1"
 
 mongodb@2.2.33:
   version "2.2.33"
@@ -4685,7 +4868,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-once@^1.3.0, once@^1.3.3:
+once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -4913,6 +5096,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -4921,7 +5108,7 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-pify@^2.0.0:
+pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
@@ -5525,7 +5712,7 @@ readable-stream@2.2.7:
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.3.3:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -5707,6 +5894,21 @@ request-ip@~2.0.1:
   resolved "https://registry.yarnpkg.com/request-ip/-/request-ip-2.0.2.tgz#deeae6d4af21768497db8cd05fa37143f8f1257e"
   dependencies:
     is_js "^0.9.0"
+
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.2.tgz#d1ea46d654a6ee4f8ee6a4fea1018c22911904b4"
+  dependencies:
+    bluebird "^3.5.0"
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
 
 request@2, request@^2.81.0:
   version "2.83.0"
@@ -5942,6 +6144,12 @@ scss-tokenizer@^0.2.3:
   dependencies:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
+
+seek-bzip@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.5.tgz#cfe917cb3d274bcffac792758af53173eb1fabdc"
+  dependencies:
+    commander "~2.8.1"
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -6191,6 +6399,10 @@ stdout-stream@^1.4.0:
   dependencies:
     readable-stream "^2.0.1"
 
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+
 stream-browserify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
@@ -6286,6 +6498,12 @@ strip-bom@^2.0.0:
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
+strip-dirs@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/strip-dirs/-/strip-dirs-2.1.0.tgz#4987736264fc344cf20f6c34aca9d13d1d4ed6c5"
+  dependencies:
+    is-natural-number "^4.0.1"
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -6400,6 +6618,15 @@ tar-pack@^3.4.0:
     tar "^2.2.1"
     uid-number "^0.0.6"
 
+tar-stream@^1.5.2:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.5.tgz#5cad84779f45c83b1f2508d96b09d88c7218af55"
+  dependencies:
+    bl "^1.0.0"
+    end-of-stream "^1.0.0"
+    readable-stream "^2.0.0"
+    xtend "^4.0.0"
+
 tar@^2.0.0, tar@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
@@ -6486,7 +6713,7 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
-tough-cookie@~2.3.0, tough-cookie@~2.3.3:
+tough-cookie@>=2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
@@ -6597,6 +6824,13 @@ uid2@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/uid2/-/uid2-0.0.3.tgz#483126e11774df2f71b8b639dcd799c376162b82"
 
+unbzip2-stream@^1.0.9:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz#73a033a567bbbde59654b193c44d48a7e4f43c47"
+  dependencies:
+    buffer "^3.0.1"
+    through "^2.3.6"
+
 undefsafe@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-0.0.3.tgz#ecca3a03e56b9af17385baac812ac83b994a962f"
@@ -6628,6 +6862,10 @@ unique-temp-dir@^1.0.0:
     mkdirp "^0.5.1"
     os-tmpdir "^1.0.1"
     uid2 "0.0.3"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -6702,7 +6940,7 @@ uuid@3.0.x:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
-uuid@^3.0.0, uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
@@ -6964,3 +7202,10 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yauzl@^2.4.2:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.9.1.tgz#a81981ea70a57946133883f029c5821a89359a7f"
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.0.1"


### PR DESCRIPTION
Notes:
- server/app.js is the express app split out of server/index.js.  This is necessary because supertest's `request()` requires a server that doesn't call `.listen()`.
- These tests are different than the ones we have written for the controllers so far, as they do not use sinon and instead use MongodbMemoryServer. We could perhaps do a combination of both?

I'm still learning so I don't know a lot about this. any comments would be nice :)