### PR TITLE
Chore/#153725201 - Fix server logger

### DIFF
--- a/server/config/rollbar.js
+++ b/server/config/rollbar.js
@@ -1,8 +1,9 @@
 const config = {
   accessToken: process.env.ROLLBAR_API_KEY,
+  enabled: true,
+  verbose: true,
   captureUncaught: true,
   captureUnhandledRejections: true,
-  verbose: true,
   ...envConfig()
 }
 
@@ -10,7 +11,7 @@ function envConfig () {
   switch (process.env.NODE_ENV) {
     case 'prod': return { environment: 'prod', reportLevel: 'error', verbose: false }
     case 'test': return { environment: 'test', reportLevel: 'warning' }
-    default: return { environment: 'dev', reportLevel: 'debug', enabled: false }
+    default: return { environment: 'dev', enabled: false }
   }
 }
 

--- a/server/logger.js
+++ b/server/logger.js
@@ -12,10 +12,10 @@ const logger = {
   log: handleLog('log')
 }
 
-function handleLog (rollbarLevel, localLevel = rollbarLevel) {
-  return function (message) {
+function handleLog (rollbarLevel = 'debug', localLevel = rollbarLevel) {
+  return function () {
     if (rollbarConfig.enabled) {
-      rollbar[rollbarLevel](message)
+      rollbar[rollbarLevel](...arguments)
     } else if (rollbarConfig.verbose) {
       console[localLevel](...arguments)
     }

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,17 +1,47 @@
 const Rollbar = require('rollbar')
 
 const { rollbarConfig } = require('./config')
+const { enabled, verbose } = rollbarConfig
 const rollbar = new Rollbar(rollbarConfig)
 
 const logger = {
-  // Forward these errors to rollbar, verbose option decides to log locally
-  critical (error) { rollbar.critical(error) },
-  error (error) { rollbar.error(error) },
-  warn (warning) { rollbar.warning(warning) },
-  // These will never report to rollbar, manually check verbose option
-  info (...args) { if (rollbarConfig.verbose) { console.info.apply(console, args) } },
-  debug (...args) { if (rollbarConfig.verbose) { console.log.apply(console, args) } },
-  log (...args) { this.debug.apply(this.debug, args) }
+  critical (error) {
+    if (enabled) {
+      rollbar.critical(error)
+    } else if (verbose) {
+      console.error.apply(console, arguments)
+    }
+  },
+  error (error) {
+    if (enabled) {
+      rollbar.error(error)
+    } else if (verbose) {
+      console.error.apply(console, arguments)
+    }
+  },
+  warn (warning) {
+    if (enabled) {
+      rollbar.warning(warning)
+    } else if (verbose) {
+      console.warn.apply(console, arguments)
+    }
+  },
+  info (message) {
+    if (enabled) {
+      rollbar.info(message)
+    } else if (verbose) {
+      console.info.apply(console, arguments)
+    }
+  },
+  debug (message) {
+    if (enabled) {
+      rollbar.debug(message)
+    } else if (verbose) {
+      console.log.apply(console, arguments)
+    }
+  },
+  warning () { this.warn.apply(this.warn, arguments) },
+  log () { this.debug.apply(this.debug, arguments) }
 }
 
 module.exports = logger

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,47 +1,25 @@
 const Rollbar = require('rollbar')
 
 const { rollbarConfig } = require('./config')
-const { enabled, verbose } = rollbarConfig
 const rollbar = new Rollbar(rollbarConfig)
 
 const logger = {
-  critical (error) {
-    if (enabled) {
-      rollbar.critical(error)
-    } else if (verbose) {
-      console.error.apply(console, arguments)
+  critical: handleLog('critical', 'error'),
+  error: handleLog('error'),
+  warn: handleLog('warn'),
+  info: handleLog('info'),
+  debug: handleLog('debug'),
+  log: handleLog('log')
+}
+
+function handleLog (rollbarLevel, localLevel = rollbarLevel) {
+  return function (message) {
+    if (rollbarConfig.enabled) {
+      rollbar[rollbarLevel](message)
+    } else if (rollbarConfig.verbose) {
+      console[localLevel](...arguments)
     }
-  },
-  error (error) {
-    if (enabled) {
-      rollbar.error(error)
-    } else if (verbose) {
-      console.error.apply(console, arguments)
-    }
-  },
-  warn (warning) {
-    if (enabled) {
-      rollbar.warning(warning)
-    } else if (verbose) {
-      console.warn.apply(console, arguments)
-    }
-  },
-  info (message) {
-    if (enabled) {
-      rollbar.info(message)
-    } else if (verbose) {
-      console.info.apply(console, arguments)
-    }
-  },
-  debug (message) {
-    if (enabled) {
-      rollbar.debug(message)
-    } else if (verbose) {
-      console.log.apply(console, arguments)
-    }
-  },
-  warning () { this.warn.apply(this.warn, arguments) },
-  log () { this.debug.apply(this.debug, arguments) }
+  }
 }
 
 module.exports = logger


### PR DESCRIPTION
Notes:
- Logging is determined by two rollbar config factors: `enabled` and `verbose`
- If `enabled`, logging is forwarded to rollbar. `verbose` is then used by rollbar to determine if the console logs what rollbar logs
- If `!enabled`, `verbose` determines if the console does the logging
- If we wanted no logging at all in an environment, both `enabled` and `verbose` would need to be set to false
- `logger.debug` won't log to console in development environment in node v9.2.0 because the console doesn't have a debug function until v9.3.0