### PR TITLE
Chore/#153805436 - Don't capture unhandled exceptions and rejections in dev

### DIFF
--- a/server/config/rollbar.js
+++ b/server/config/rollbar.js
@@ -11,7 +11,7 @@ function envConfig () {
   switch (process.env.NODE_ENV) {
     case 'prod': return { environment: 'prod', reportLevel: 'error', verbose: false }
     case 'test': return { environment: 'test', reportLevel: 'warning' }
-    default: return { environment: 'dev', enabled: false }
+    default: return { enabled: false, captureUncaught: false, captureUnhandledRejections: false }
   }
 }
 


### PR DESCRIPTION
Unhandled exceptions and promise rejections should no longer result in hidden errors that just say "rollbar is not enabled".

Rollbar was attempting to capture these exceptions even when disabled, and since rollbar is disabled in dev mode the above would happen. This should fix it!