### PR TITLE
Fix/#153931848 - Cannot run local test environment

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -19,6 +19,7 @@ COPY package.json yarn.lock $WORKDIR/
 RUN cd $WORKDIR && \
     yarn --production
 COPY deploy/dist ${WORKDIR}/
+COPY deploy/test ${WORKDIR}/deploy/test
 
 WORKDIR $WORKDIR
 EXPOSE 3000

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -56,6 +56,8 @@ $ yarn db
 $ yarn start:dev
 ```
 
+The app can then be viewed at `localhost:3000/`
+
 Use this for simulating the test environment through Docker:
 
 ```bash
@@ -64,6 +66,8 @@ $ yarn start
 # When finished, stop the app
 $ yarn stop
 ```
+
+The app can then be viewed at `https://localhost:3000/`
 
 *Note: ports 3000, 27017, and 28017 will need to be available on your machine to run the app. If you run into a problem here, checkout our [database troubleshooting](./PROBLEMS.md#database).*
 


### PR DESCRIPTION
This should fix the issue on our `blueberrymozart/test-c2c` docker image so that running `yarn start` doesn't give an error