### PR TITLE
Chore/#154033587 - Refactor controller function bindings

### DIFF
--- a/server/bindFunctions.js
+++ b/server/bindFunctions.js
@@ -1,0 +1,16 @@
+function bindFunctions (self) {
+  const reserved = ['_init', 'constructor']
+  const props = self.constructor.name === 'Object'
+    ? Object.getOwnPropertyNames(self) // Regular object
+    : Object.getOwnPropertyNames(self.constructor.prototype) // Class object
+
+  for (const prop of props) {
+    const val = self[prop]
+
+    if (typeof val === 'function' && reserved.every(r => !prop.startsWith(r))) {
+      self[prop] = val.bind(self)
+    }
+  }
+}
+
+module.exports = bindFunctions

--- a/server/bindFunctions.test.js
+++ b/server/bindFunctions.test.js
@@ -2,7 +2,9 @@ const test = require('ava')
 
 const bindFunctions = require('./bindFunctions')
 
-const testMessage = 'test message'
+test.beforeEach(t => {
+  t.context.testMessage = 'test message'
+})
 
 test('bindFunctions works with objects', t => {
   const controller = {
@@ -18,6 +20,7 @@ test('bindFunctions works with objects', t => {
     }
   }
 
+  const { testMessage } = t.context
   const ctrl = controller._init(testMessage)
   const sendMessage = ctrl.sendMessage
 
@@ -37,6 +40,7 @@ test('bindFunctions works with classes', t => {
     }
   }
 
+  const { testMessage } = t.context
   const ctrl = new Controller(testMessage)
   const sendMessage = ctrl.sendMessage
 

--- a/server/bindFunctions.test.js
+++ b/server/bindFunctions.test.js
@@ -1,0 +1,44 @@
+const test = require('ava')
+
+const bindFunctions = require('./bindFunctions')
+
+const testMessage = 'test message'
+
+test('bindFunctions works with objects', t => {
+  const controller = {
+    _init (message) {
+      bindFunctions(this)
+
+      this.message = message
+      return this
+    },
+
+    sendMessage () {
+      return this.message
+    }
+  }
+
+  const ctrl = controller._init(testMessage)
+  const sendMessage = ctrl.sendMessage
+
+  t.is(sendMessage(), testMessage)
+})
+
+test('bindFunctions works with classes', t => {
+  class Controller {
+    constructor (message) {
+      bindFunctions(this)
+
+      this.message = message
+    }
+
+    sendMessage () {
+      return this.message
+    }
+  }
+
+  const ctrl = new Controller(testMessage)
+  const sendMessage = ctrl.sendMessage
+
+  t.is(sendMessage(), testMessage)
+})

--- a/server/routes/controllers/emailController.js
+++ b/server/routes/controllers/emailController.js
@@ -1,12 +1,14 @@
 const sendgrid = require('@sendgrid/mail')
+
+const bindFunctions = require('../../bindFunctions')
 const { emailConfig } = require('../../config')
 
 const emailController = {
   _init (emailClient = sendgrid) {
+    bindFunctions(this)
+
     this.emailClient = emailClient
     this.emailClient.setApiKey(emailConfig.sendgridApiKey)
-
-    this.sendToOrg = this.sendToOrg.bind(this)
     return this
   },
 

--- a/server/routes/controllers/forgotPasswordController.js
+++ b/server/routes/controllers/forgotPasswordController.js
@@ -1,13 +1,15 @@
 const sendgrid = require('@sendgrid/mail')
+
+const bindFunctions = require('../../bindFunctions')
 const ForgotPasswordModel = require('../../database/models/ForgotPassword')
 
 const forgotPasswordController = {
   _init (emailClient = sendgrid, ForgotPass = ForgotPasswordModel) {
+    bindFunctions(this)
+
     emailClient.setApiKey(process.env.SENDGRID_API_KEY)
     this.emailClient = emailClient
     this.ForgotPass = ForgotPass
-    this.sendVerificationCodeEmail = this.sendVerificationCodeEmail.bind(this)
-
     return this
   },
 

--- a/server/routes/controllers/indexController.js
+++ b/server/routes/controllers/indexController.js
@@ -1,10 +1,12 @@
 const path = require('path')
 
+const bindFunctions = require('../../bindFunctions')
+
 const indexController = {
   _init (pathResolver = path) {
+    bindFunctions(this)
+    
     this.indexFilePath = pathResolver.join(__dirname, '..', '..', 'public', 'index.html')
-
-    this.getIndexPage = this.getIndexPage.bind(this)
     return this
   },
 

--- a/server/routes/controllers/projectsController.js
+++ b/server/routes/controllers/projectsController.js
@@ -1,11 +1,11 @@
+const bindFunctions = require('../../bindFunctions')
 const ProjectModel = require('../../database/models/Project')
 
 const projectsController = {
   _init (Projects = ProjectModel) {
-    this.Projects = Projects
+    bindFunctions(this)
 
-    this.getProjects = this.getProjects.bind(this)
-    this.getProject = this.getProject.bind(this)
+    this.Projects = Projects
     return this
   },
 

--- a/server/routes/controllers/usersController.js
+++ b/server/routes/controllers/usersController.js
@@ -1,18 +1,11 @@
+const bindFunctions = require('../../bindFunctions')
 const UserModel = require('../../database/models/User')
 
 const usersController = {
   _init (Users = UserModel) {
-    this.Users = Users
+    bindFunctions(this)
 
-    this.getCurrent = this.getCurrent.bind(this)
-    this.putCurrent = this.putCurrent.bind(this)
-    this.getUsers = this.getUsers.bind(this)
-    this.signup = this.signup.bind(this)
-    this.getUser = this.getUser.bind(this)
-    this.putUser = this.putUser.bind(this)
-    this.getSalt = this.getSalt.bind(this)
-    this.login = this.login.bind(this)
-    this.changePassword = this.changePassword.bind(this)
+    this.Users = Users
     return this
   },
 


### PR DESCRIPTION
A utility `bindFunctions` has been created that allows our controllers to more easily and cleanly bind their `this` context to their functions. 

**Example:**
A controller's `_init` function originally looks like this:
```
const usersController = {
  _init (Users = UserModel) {
    this.Users = Users

    this.getUsers = this.getUsers.bind(this)
    this.signup = this.signup.bind(this)		
    this.getUser = this.getUser.bind(this)		
    this.putUser = this.putUser.bind(this)		
    this.getSalt = this.getSalt.bind(this)		
    this.login = this.login.bind(this)		
    this.changePassword = this.changePassword.bind(this)
    return this
  },
  ...
}
```

Now it looks like this:
```
const bindFunctions = require('../../bindFunctions')

const usersController = {
  _init (Users = UserModel) {
    bindFunctions(this)

    this.Users = Users
    return this
  },
  ...
}
```

**Notes:**
- `bindFunctions(this)` must happen before any other `this` assigning. The reason for this is we don't want to bind the `this` context of external functions that are assigned to the controller's `this` during `_init`. For example, mongoose models are actually functions, so if they are bound to the controller's `this` prior to `bindFunctions(this)`, their `this` context will be overwritten with the controller's `this`.
  