### PR TITLE
Chore/#154313775 - Reset mongodb on test environment through CI/CD

### DIFF
--- a/.deploy/deploy.sh
+++ b/.deploy/deploy.sh
@@ -25,3 +25,13 @@ mongo "mongodb://$DB_HOST/test?replicaSet=$DB_REPLICA_SET" \
   -u admin \
   -p $DB_PASS \
   --eval 'db.users.drop(); db.projects.drop()'
+
+MONGO_HOST="$DB_REPLICA_SET/$DB_HOST"
+mongoimport --collection users --db test \
+  -h $MONGO_HOST \
+  --ssl -u admin -p $DB_PASS --authenticationDatabase admin \
+  --file ../.setup/db/seedData/users.json --type json --jsonArray
+mongoimport --collection projects --db test \
+  -h $MONGO_HOST \
+  --ssl -u admin -p $DB_PASS --authenticationDatabase admin \
+  --file ../.setup/db/seedData/projects.json --type json --jsonArray

--- a/.deploy/deploy.sh
+++ b/.deploy/deploy.sh
@@ -17,3 +17,11 @@ aws elasticbeanstalk create-application-version --application-name calltocode \
 aws elasticbeanstalk update-environment --environment-name test-calltocode \
   --version-label $TRAVIS_COMMIT \
   --region us-east-2
+
+# reset mongodb
+mongo "mongodb://$DB_HOST/test?replicaSet=$DB_REPLICA_SET" \
+  --ssl \
+  --authenticationDatabase admin \
+  -u admin \
+  -p $DB_PASS \
+  --eval 'db.users.drop(); db.projects.drop()'

--- a/.setup/db/run.sh
+++ b/.setup/db/run.sh
@@ -45,32 +45,17 @@ stop () {
   docker rm $ID | xargs echo "--- Removed container"
 }
 
-init_test () {
-  set -u
-  MONGO_HOST="$DB_REPLICA_SET/$DB_HOST"
-  mongoimport --collection users --db test \
-    -h $MONGO_HOST \
-    --ssl -u admin -p $DB_PASS --authenticationDatabase admin \
-    --file ./.setup/db/seedData/users.json --type json --jsonArray
-  mongoimport --collection projects --db test \
-    -h $MONGO_HOST \
-    --ssl -u admin -p $DB_PASS --authenticationDatabase admin \
-    --file ./.setup/db/seedData/projects.json --type json --jsonArray
-}
-
 info () {
 cat <<EOF
   Usage: ./db/run.sh <target>
   Targets:
     start - start a docker container with seeded MongoDB
     stop - stop and remove the docker container
-    init_test - populate cloud mongodb for test environment
 EOF
 }
 
 case $1 in
   start)        start         ;;
   stop)         stop          ;;
-  init_test)    init_test     ;;
   *)            info          ;;
 esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: node_js
 
 services:
 - docker
+- mongodb
 
 branches:
   only:


### PR DESCRIPTION
Reset DB in TEST environment by dropping the `users` and `projects` collections and re-populating them. Additional collections can included this way in the future.