### PR TITLE
Add fix for handling responses that are not json

### DIFF
--- a/client/api/lib/apiRequest.js
+++ b/client/api/lib/apiRequest.js
@@ -20,7 +20,11 @@ async function apiRequest (apiOptions, options) {
     console.log(res)
   }
 
-  return res.json()
+  const contentType = res.headers.get('Content-Type')
+  if (contentType && contentType.indexOf('application/json') !== -1) {
+    return res.json()
+  }
+  return res
 }
 
 function getQueryString (query = {}) {


### PR DESCRIPTION
This is a placeholder, to not introduce regressions with the earlier mongoose PR which opted to use `res.sendStatus(200)` versus `res.status(200).send({status: 200})` syntax for the forgot password controller.