### PR TITLE
Feature/#153534540 - Visitor (before login) should not be able to see the checkmark/cross symbols or hover over projects

### DIFF
--- a/client/components/Project/Project.js
+++ b/client/components/Project/Project.js
@@ -26,15 +26,11 @@ class Project extends Component {
   renderProjectApplicationResult (project) {
     const applied = this.getAppliedStatus()
     const isContact = this.isUserTypeContact()
-    if (applied && !isContact) {
-      return (
-        <span className={styles.projectApplyPass}>&#10004;</span>
-      )
-    } else if (!isContact) {
-      return (
-        <span className={styles.projectApplyFail}>&#10007;</span>
-      )
+    if (this.props.authenticated && !isContact) {
+      return applied ? <span className={styles.projectApplyPass}>&#10004;</span>
+        : <span className={styles.projectApplyFail}>&#10007;</span>
     }
+    return <span />
   }
 
   getAppliedStatus () {


### PR DESCRIPTION
Changed the way the cross or tick were being shown for non authenticated users.